### PR TITLE
Windows에서 jekyll 실행시 성능관련 경고문구에 대응하라

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'jekyll-paginate'
 gem 'jekyll-gist'
+
+# On Windows, you need to install 'wdm' , to avoid polling for changes
+# For more details, please check  https://jekyllrb.com/docs/installation/windows/#auto-regeneration
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
윈도우에서 `bundle exec jekyll serve` 실행하면  아래와 같이 경고가 나옵니다. (실행은 문제없음)
![get_wdm_워닝](https://user-images.githubusercontent.com/24635919/77805985-bc1bde80-70c6-11ea-8b89-773c3ec84a0a.png)

[관련해서 정보](https://jekyllrb.com/docs/installation/windows/#auto-regeneration)를 찾아보니 jekyll이 파일 변동 체크시 [`listen`](https://github.com/guard/listen#listen-adapters)을 사용하는데 `wdm`을 사용하지 않으면 polling 방식을 사용하여 느려질수 있다고 합니다.

선택적으로 window 플랫폼만 설치하도록  설정되므로 스켈레톤에 머지했으면 합니다.