### PR TITLE
toc highlighter의 불필요한 계산을 제거하라

### DIFF
--- a/js/toc-highlight.js
+++ b/js/toc-highlight.js
@@ -47,6 +47,9 @@
         for (let i = 0; i < headings.length; i++) {
             const y = headings[i].getBoundingClientRect().top - 35;
 
+            if (y > 0) {
+                break;
+            }
             if (y <= 0 && y > currentHeading.getBoundingClientRect().top) {
                 currentHeading = headings[i];
             }
@@ -54,10 +57,16 @@
         return currentHeading;
     }
 
+    let activeHeadingId = null;
     document.body.onscroll = function() {
-        deActivate();
         const currentHeading = findCurrentHeading(headings);
-        console.log(currentHeading)
+
+        if (currentHeading.id == activeHeadingId) {
+            return;
+        }
+        // console.log(currentHeading)
+        deActivate();
         activate(tocMap[currentHeading.id]);
+        activeHeadingId = currentHeading.id;
     }
 })();


### PR DESCRIPTION
- highlight 대상 탐색시, 대상을 찾으면 for문을 탈출하도록 수정했습니다.
- highlight 적용시, 대상이 이미 highlight되어 있다면 작업을 하지 않도록 수정했습니다.