### PR TITLE
Gemfile에 빠진 kramdown-parser-gfm의존성을 추가하라

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,6 @@ gem 'jekyll-gist'
 # On Windows, you need to install 'wdm' , to avoid polling for changes
 # For more details, please check  https://jekyllrb.com/docs/installation/windows/#auto-regeneration
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+
+gem 'kramdown-parser-gfm'
+


### PR DESCRIPTION
Gemfile에 kramdown-parser-gfm의존성이 빠져있습니다. 그래서 `jekyll serve`로 실행하면 에러가 발생합니다.
그래서 Gemfile에 kramdown-parse-gfm의존성을 추가했습니다.

```bash
$ bundle install
$ jekyll serve
Dependency Error: Yikes! It looks like you don't have kramdown-parser-gfm or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- kramdown-parser-gfm' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
Conversion error: Jekyll::Converters::Markdown encountered an error while converting '_posts/2017/2017-03-12-telegram-bot.md':
                  kramdown-parser-gfm
           ERROR: YOUR SITE COULD NOT BE BUILT:
                  ------------------------------------
                  kramdown-parser-gfm
```

See also
  - https://github.com/kramdown/parser-gfm