### PR TITLE
블로그 모바일에서 우측의 여백을 제거하라

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -197,6 +197,7 @@ div.search {
     line-height: 1;
 }
 .searchInput {
+    box-sizing: border-box;
     background-color: transparent;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
모바일에서 보면 가로로 스크롤이 됩니다. 그래서 위 아래로 스크롤 하려고
해도 옆으로 흔들립니다.
가로로 스크롤 되지 않도록 길이를 조정했습니다.

![image](https://user-images.githubusercontent.com/14071105/198170321-ab9e108f-4325-4df1-96b5-1dbeb12909ee.png)

위의 사진을 보시면 우측에 5px정도 여백이 있어서, 디바이스 크기 보다 5px 큰 요소 때문에 가로로 스크롤 됩니다.

![image](https://user-images.githubusercontent.com/14071105/198170338-28109cd4-5c8e-4d60-9218-dfee12f7966e.png)

범인은 바로 위의 `input`태그였습니다. 길이가 100% 인데, 왼쪽 패딩이 5px이 있어서 길이가 100% + 5px이 되어버립니다.

길이가 패딩을 포함한 길이로 100%가 되도록 하기 위해 `box-sizing`속성을 `border-box`로 수정했습니다.

See also
  - https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing

